### PR TITLE
Change project structure to .Net conventions

### DIFF
--- a/csharp/ClarifyException.sln
+++ b/csharp/ClarifyException.sln
@@ -1,9 +1,11 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.28010.2003
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30309.148
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ClarifyException", "ClarifyException\ClarifyException.csproj", "{AEE68BE5-D906-4521-B9B6-2D199A344BBA}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ClarifyException", "ClarifyException\ClarifyException.csproj", "{AEE68BE5-D906-4521-B9B6-2D199A344BBA}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ClarifyExceptionTests", "ClarifyExceptionTests\ClarifyExceptionTests.csproj", "{3E8F0B37-26B1-4193-A568-CD2E964A5A36}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -15,6 +17,10 @@ Global
 		{AEE68BE5-D906-4521-B9B6-2D199A344BBA}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{AEE68BE5-D906-4521-B9B6-2D199A344BBA}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{AEE68BE5-D906-4521-B9B6-2D199A344BBA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3E8F0B37-26B1-4193-A568-CD2E964A5A36}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3E8F0B37-26B1-4193-A568-CD2E964A5A36}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3E8F0B37-26B1-4193-A568-CD2E964A5A36}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3E8F0B37-26B1-4193-A568-CD2E964A5A36}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/csharp/ClarifyException/ClarifyException.csproj
+++ b/csharp/ClarifyException/ClarifyException.csproj
@@ -5,11 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="ApprovalTests" Version="5.2.5" />
   </ItemGroup>
 
 </Project>

--- a/csharp/ClarifyExceptionTests/ClarifyExceptionTests.csproj
+++ b/csharp/ClarifyExceptionTests/ClarifyExceptionTests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="ApprovalTests" Version="5.2.5" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+    <PackageReference Include="coverlet.collector" Version="1.2.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\ClarifyException\ClarifyException.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/csharp/ClarifyExceptionTests/MessageEnricherTest.SampleTest.approved.txt
+++ b/csharp/ClarifyExceptionTests/MessageEnricherTest.SampleTest.approved.txt
@@ -1,0 +1,1 @@
+ErrorResult{formulaName='Name of the formula', message='Terrible problem', presentation='Presentation of which cells in the spreadsheet are populated with numbers and formulas and things'}

--- a/csharp/ClarifyExceptionTests/MessageEnricherTest.cs
+++ b/csharp/ClarifyExceptionTests/MessageEnricherTest.cs
@@ -1,11 +1,8 @@
-﻿using ApprovalTests;
-using System;
-using ApprovalTests.Reporters;
+﻿using System;
 using Xunit;
 
 namespace codingdojo
 {
-    [UseReporter(typeof(DiffReporter))]
     public class MessageEnricherTest
     {
         [Fact]
@@ -19,7 +16,7 @@ namespace codingdojo
 
             var actual = enricher.EnrichError(worksheet, e);
 
-            Approvals.Verify(actual);
+            Assert.Equal("Fixme", actual.Message);
         }
     }
 }

--- a/csharp/ClarifyExceptionTests/MessageEnricherTest.cs
+++ b/csharp/ClarifyExceptionTests/MessageEnricherTest.cs
@@ -1,8 +1,11 @@
-﻿using System;
+﻿using ApprovalTests;
+using System;
+using ApprovalTests.Reporters;
 using Xunit;
 
 namespace codingdojo
 {
+    [UseReporter(typeof(DiffReporter))]
     public class MessageEnricherTest
     {
         [Fact]
@@ -16,7 +19,7 @@ namespace codingdojo
 
             var actual = enricher.EnrichError(worksheet, e);
 
-            Assert.Equal("Fixme", actual.Message);
+            Approvals.Verify(actual);
         }
     }
 }


### PR DESCRIPTION
For a Kata sesssion I wanted to show the participants mutation testing as a way to check if 100% coverage is enough.
For c# we used Stryker.Net which needs the test code to be in a separate project than the mutated code. I am not a .NET expert but it seems to be the conventional way to have the tests in a separate project.